### PR TITLE
♻️ refactor: 표시 이름에 '젖' 접두사 강제 추가 로직 제거

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "theburgers",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "CHZZK와 Discord 연동 봇 프로젝트",
   "main": "dist/index.js",
   "scripts": {

--- a/src/countManager.ts
+++ b/src/countManager.ts
@@ -152,7 +152,7 @@ export class CountManager implements CleanupableService {
       
       return embed
         .setColor(color)
-        .setTitle(`${emoji} 젖${displayName} 알림 ${emoji}`)
+        .setTitle(`${emoji} ${displayName} 알림 ${emoji}`)
         .setDescription(description)
         .setURL(CONFIG.CHZZK_LIVE_URL);
     } catch (error) {

--- a/src/web/public/js/dashboard.js
+++ b/src/web/public/js/dashboard.js
@@ -296,7 +296,7 @@ class ConfigurationDashboard {
         
         document.getElementById('previewEmoji').textContent = emoji;
         document.getElementById('previewEmoji2').textContent = emoji;
-        document.getElementById('previewText').textContent = `젖${displayName} 알림`;
+        document.getElementById('previewText').textContent = `${displayName} 알림`;
     }
 
     async saveGroup() {
@@ -754,7 +754,7 @@ class ConfigurationDashboard {
         const formData = this.getGroupFormData();
         const testText = formData.characters.join('');
         
-        this.showToast(`테스트 패턴: "${testText}" → ${formData.emoji} 젖${formData.display_name} 알림 ${formData.emoji}`, 'success');
+        this.showToast(`테스트 패턴: "${testText}" → ${formData.emoji} ${formData.display_name} 알림 ${formData.emoji}`, 'success');
     }
 
     addMessageInput() {


### PR DESCRIPTION
알림 생성 시와 웹 대시보드 미리보기에서 '젖' 접두사가 강제로 추가되는 문제를 수정했습니다. 이제 각 그룹의 표시 이름이 그대로 사용됩니다.